### PR TITLE
change eclipse.org to eclipseide.org

### DIFF
--- a/app/data/javadoc.json
+++ b/app/data/javadoc.json
@@ -79,7 +79,7 @@
   "rfc-8017":                            "https://www.ietf.org/rfc/rfc8017.html",
   "ANSI-20X9.62":                        "https://standards.globalspec.com/std/1955141/ANSI%20X9.62",
 
-  "ide-eclipse":  "https://www.eclipse.org/",
+  "ide-eclipse":  "https://www.eclipseide.org/",
   "ide-netbeans": "https://netbeans.apache.org/",
   "ide-intellij": "https://www.jetbrains.com/idea/",
 


### PR DESCRIPTION
### Website section
`Running Your First Java Application`>`Getting Started with java`

### Details
The link `the Eclipse foundation maintains Eclipse` refers to https://eclipse.org which is used by the Eclipse Foundation in general.
However, the website of the Eclipse IDE specifically is https://eclipseide.org.

This PR updates that link.