### PR TITLE
improve usability with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ WORKDIR /app
 
 COPY ["package.json", "./"]
 COPY ["gulpfile.js", "./"]
-COPY ["app", "./app"]
 
 RUN npm install gulp -g
 RUN npm install
+
+COPY ["app", "./app"]
+
 RUN gulp build
 
 CMD ["gulp", "serve"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A browser should launch viewing [https://localhost:3000](https://localhost:3000)
 ### Option 2: Use Docker
 
 1. `docker build --tag devjava .`
-1. `docker run --publish 3000:3000 --rm devjava`
+1. `docker run --publish 3000:3000 --init -it --rm devjava`
 
 You should then be able to open a browser and visit [https://localhost:3000](https://localhost:3000)
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A browser should launch viewing [https://localhost:3000](https://localhost:3000)
 
 You should then be able to open a browser and visit [https://localhost:3000](https://localhost:3000)
 
-(if you want to mount a volume to automatically refresh the page as you type add option `-v $PWD/app:/app/app` to your `docker run` command above)
+(For a more dynamic development experience avoiding a Docker build after every change, you can mount the local /app folder to the container by adding option `-v $PWD/app:/app/app` to your `docker run` command. Note: $PWD may not work in Windows.)
 
 
 ## Working with Content

--- a/README.md
+++ b/README.md
@@ -91,10 +91,8 @@ A browser should launch viewing [https://localhost:3000](https://localhost:3000)
 
 You should then be able to open a browser and visit [https://localhost:3000](https://localhost:3000)
 
-In order to automatically update the site when editing an article, it is possible to mount a volume:
+(if you want to mount a volume to automatically refresh the page as you type add option `-v $PWD/app:/app/app` to your `docker run` command above)
 
-1. `docker build --tag devjava .`
-1. `docker run --publish 3000:3000 --rm -v $PWD/app:/app/app devjava`
 
 ## Working with Content
 

--- a/README.md
+++ b/README.md
@@ -86,11 +86,15 @@ A browser should launch viewing [https://localhost:3000](https://localhost:3000)
 
 ### Option 2: Use Docker
 
-1. docker build --tag devjava .
-1. docker run --publish 3000:3000 devjava
+1. `docker build --tag devjava .`
+1. `docker run --publish 3000:3000 --rm devjava`
 
 You should then be able to open a browser and visit [https://localhost:3000](https://localhost:3000)
 
+In order to automatically update the site when editing an article, it is possible to mount a volume:
+
+1. `docker build --tag devjava .`
+1. `docker run --publish 3000:3000 --rm -v $PWD/app:/app/app devjava`
 
 ## Working with Content
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -415,10 +415,10 @@ function serve(done) {
         }
     });
 
-    watch("app/**/*.md", {}, series(build));
-    watch("app/**/*.html", {}, series(build));
-    watch("app/scss/*.scss", {}, series(build));
-    watch("site/**/", {}, browserSync.reload());
+    watch("app/**/*.md", {interval: 1000, usePolling: true}, series(build));
+    watch("app/**/*.html", {interval: 1000, usePolling: true}, series(build));
+    watch("app/scss/*.scss", {interval: 1000, usePolling: true}, series(build));
+    watch("site/**/", {interval: 1000, usePolling: true}, browserSync.reload());
     done();
 }
 


### PR DESCRIPTION
Currently, writing/changing articles with the Docker tooling is a bit annoying as one always needs to rebuild the image when changing something which also requires the `npm install` to execute again.

This PR performs the following changes:
- It reorders the operations in the `Dockerfile` to run `npm install` before copying the files resulting in further executions being able to use a cached image and not run `npm install` again when changing a file.
- For consistency, inline codeblocks have been added to the Docker instructions in the `README.md`.
- `--rm` is added to the instructions in the `README.md` in order to automatically remove the container after it terminates.
- Instructions for starting it with volumes have been added to the `README.md`. If this command is used and an article is added after starting the server, it automatically reloads the site.

### potential issues
- Windows: On Windows, `$PWD` may not be available. It might be a good idea to add instructions for that.

### other considerations
Since I added `--rm`, it would be possible to give the container a name using the `--name` option.