### PR TITLE
fix wrong JDK version for record introduction of enums article

### DIFF
--- a/app/pages/learn/01_tutorial/03_getting-to-know-the-language/04_classes_objects/01_enums.md
+++ b/app/pages/learn/01_tutorial/03_getting-to-know-the-language/04_classes_objects/01_enums.md
@@ -212,6 +212,6 @@ and reading these configuration files in the program in cases like this.
 <a id="conclusion">&nbsp;</a>
 ## Conclusion
 
-Enums provide a simple and safe way of representing a fixed set of constants while keeping most of the flexibilities of classes. They are a special type of class that can be used to write code that is elegant, readable, maintainable and works well with other modern Java features like [switch expressions](id:lang.classes-objects.switch-expression). Another special class is the Record class introduced in Java 19. Visit our [records tutorial](id:lang.records) to learn more.
+Enums provide a simple and safe way of representing a fixed set of constants while keeping most of the flexibilities of classes. They are a special type of class that can be used to write code that is elegant, readable, maintainable and works well with other modern Java features like [switch expressions](id:lang.classes-objects.switch-expression). Another special class is the Record class introduced in JDK 16. Visit our [records tutorial](id:lang.records) to learn more.
 
 To learn more about enums, visit the [`java.lang.Enum`](javadoc:Enum) javadoc.


### PR DESCRIPTION
As reported in #137, the article about enums (#45) states the wrong JDK version for the introduction of records.

This PR changes it to JDK 16 which is [when Records have been introduced](https://openjdk.org/jeps/395):
![image](https://github.com/user-attachments/assets/6df0cbaa-1e66-4fd4-890b-f1655aaa6d30)

I haven't included the version when records have been introduced as a Preview feature since I think most people reading the article about enums are probably not interested in the exact history of records, they probably only want to know when they can use it.

fixes #137 