### PR TITLE
Update for Java 25

### DIFF
--- a/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
+++ b/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
@@ -10,11 +10,11 @@ main_css_id: learn
 toc:
 - Why get Java certified? {motivation}
 - What certification exams are available? {cert-list}
-- Should I wait for Java 21? {java-21}
+- Should I wait for the next version? {next-version}
 - What is covered {topics}
 - How to study {study}
 description: "Overview of the Java Certification and how to study"
-last_update: 2023-07-30
+last_update: 2026-05-16
 author: ["JeanneBoyarsky"]
 ---
 
@@ -30,50 +30,55 @@ Learning and jobs reasons tend to be the most common reasons to get a Java certi
 <a id="cert-list">&nbsp;</a>
 ## What certification exams are available?
 
-There are currently five active Java certification exams.
+There are currently a number of active Java certification exams.
 
+1. [1Z0-831: Java SE 25 Developer Professional exam](https://education.oracle.com/java-se-25-developer-professional/pexam_1Z0-831) - 50 questions in 120 minutes, passing 68% - For Java 21; =the most recent certification exam available.
+1. [1Z0-830: Java SE 21 Developer Professional exam](https://mylearn.oracle.com/ou/exam/java-se-21-developer-professional-1z0-830/105037/139080/220555) - 50 questions in 120 minutes, passing 68% - For Java 21; =the most recent certification exam available.
 1. [1Z0-829: Java SE 17 Developer exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-829) - 50 questions, passing 68% - This Java 17 is the most recent certification exams available.
 2. [1Z0-819: Java SE 11 Developer exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-819) - 50 questions, passing 68% - For Java 11, the exam was launched in two parts like Java 8 (1Z0-815 and 1Z0-816). It was consolidated into a single exam, the 1Z0-819.  
 3. [1Z0-808: Java SE 8 Programmer I exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-808) - 56 questions, passing 65% - For Java 8, the exam was split into two parts. You earn a certification for each one. . Taking this first half gives you a more basic certification while you work towards the 809.
 4. [1Z0-809: Java SE 8 Programmer II exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-809) - 68 questions, passing 65% - This is the second half of the Java 8 exam.
 5. [1Z0-811: Java Foundations exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-811) - 60 questions, passing 65% - The foundations exam was introduced for those in Oracle Academy. It is far less common than the other exams. It uses Java 8 as well.
 
+Most people start with one of the latest two (1ZO-831 for Java 25 or 1Z0-830 for Java 21). Some start with the 1Z)-811 if they want to start with an easy certification faster. It is very important to use study materials that match the exam you are studying for. For example, those who hold Java 21 materials target the 1Z0-830 exam.
 
-Most people start with the 1Z0-808 (if you want to get an easy certification faster and build on it) or 1Z0-829 (for the latest). It is very important to use study materials that match the exam you are studying for. As a result, those who hold Java 11 materials target the 1Z0-811 exam.
-
-<a id="java-21">&nbsp;</a>
-## Should I wait for Java 21?
+<a id="next-version">&nbsp;</a>
+## Should I wait for the next version of the certification?
 
 You might have noticed that the exams target Java versions matching the LTS (long term support versions). I recommend taking an exam that is available when you want to start studying rather than waiting for the next version. It typically takes a number of months after the LTS release for the objectives/exam to come out. Then it takes time for updated certification study materials to come out. It's *a lot* harder to pass the test without study materials.
 
-Additionally, one of the benefits of a faster LTS release cycle is that the language syntax can evolve more rapidly. As a result, taking the Java 17 exam is likely to meet your goals and no need to wait for the next exam to come out/study materials to be updated.
+Additionally, one of the benefits of a faster LTS release cycle is that the language syntax can evolve more rapidly. As a result, taking the exam that matches your study materials is likely to meet your goals and no need to wait for the next exam to come out/study materials to be updated.
 
 <a id="topics">&nbsp;</a>
 ## What is covered?
 
-Each exam (see links above) has the objectives posted under "review exam topics". There are a number of top level objectives. For example, exam objectives covered in Java 17 ones are:
-* Handling date, time, text, numeric and boolean values
-* Controlling Program Flow
-* Utilizing Java Object-Oriented Approach
-* Handling Exceptions
-* Working with Arrays and Collections
-* Working with Streams and Lambda expressions
-* Packaging and deploying Java code and use the Java Platform Module System
-* Managing concurrent code execution
-* Using Java I/O API
-* Accessing databases using JDBC
-* Implementing Localization
+Each exam (see links above) has the objectives posted under "review exam topics". There are a number of top level objectives. For example, exam objectives covered in Java 25 ones are:
+* Handling Date, Time, Text, Numeric and Boolean Values
+* Implementing Program Flow Control Using Decision and Looping Constructs
+* Applying Object-Oriented Principles in Java Programs
+* Implementing Exception Handling in Java Applications
+* Using Arrays and Collections to Store and Retrieve Data
+* Processing Data Using Streams and Lambda Expressions
+* Packaging and Deploying Java Code
+* Implementing Multithreading for Concurrent Code Execution
+* Performing Input and Output Operations Using the Java I/O API
+* Developing Applications with Localization Support
 
-Then for each one there are more detailed sub-objectives. For example,  the first one has
-* Use primitives and wrapper classes including Math API, parentheses, type promotion, and casting to evaluate arithmetic and boolean expressions
-* Manipulate text, including text blocks, using String and StringBuilder classes
-* Manipulate date, time, duration, period, instant and time-zone objects using Date-Time API
+Then for each one there are more detailed sub-objectives. For example,  the streams and lambda one has:
+* Use Java object and primitive Streams, including lambda expressions implementing functional interfaces, to create, filter, transform, process, and sort data.
+* Perform decomposition, concatenation, reduction, grouping and partitioning, and gather operations on sequential and parallel streams.
 
 Your study materials will give your more details on what you specifically need to know. They will also teach you what you need to learn, point out tricks and practice questions. You should also write lots of code. It's like math; you learn better by doing as you learn!
 
 <a id="study">&nbsp;</a>
-## How to study?
+## How to study for the Java 25 certification?
 
-If you subscribe to Oracle University, there is a [24 hour video class](https://mylearn.oracle.com/ou/learning-path/become-a-java-se-17-developer/99487y). If not, there are two books: [Wiley's Sybex imprint](https://www.amazon.com/Oracle-Certified-Professional-Developer-Certification/dp/111986464X) (disclosure: I wrote this) and [Pearson/Oracle Press](https://www.amazon.com/Certified-Professional-Developer-1Z0-829-Programmers/dp/0137993641).
+If you subscribe to Oracle University, there is a [40+ hour video class](https://mylearn.oracle.com/ou/learning-path/become-a-java-se-25-developer/161648). Since the exam just launched, books are not available yet. There are Java 21 books (see next sections) and [CodeRanch provides a table comparing the objectives](https://coderanch.com/wiki/1011490/certification/Java-Java) between the Java 21 and 25 exams.
 
-Regardless of which option you chose to study, I recommend the [Enthuware mock exams](https://enthuware.com/java-certification-mock-exams/oracle-certified-professional/ocp-java-17-exam-1z0-829). They are only $10 and you get 20 mock exams! Excellent practice after you study to get ready.  The OCP forum at [CodeRanch](https://coderanch.com/f/24/java-programmer-OCPJP) is also a great place to ask questions as you prepare for your certification.
+Regardless of how you chose to study, I recommend the [Enthuware mock exams](https://enthuware.com/java-certification-mock-exams/oracle-certified-professional/ocp-java-25-exam-1z0-831). They are only $10 and you get 20 mock exams! Excellent practice after you study to get ready. The OCP forum at [CodeRanch](https://coderanch.com/f/24/java-programmer-OCPJP) is also a great place to ask questions as you prepare for your certification.
+
+## How to study for the Java 21 certification?
+
+If you subscribe to Oracle University, there is a [40+ hour video class](https://mylearn.oracle.com/ou/learning-path/become-a-java-se-21-developer/138845). If not, there are two books: [Wiley's Sybex imprint](https://www.amazon.com/Oracle-Certified-Professional-Developer-Study/dp/1394286619) (disclosure: I wrote this) and [Enthuware's three part series](https://www.amazon.com/dp/B0DTKLFP5P).
+
+Regardless of which option you chose to study, I recommend the [Enthuware mock exams](https://enthuware.com/java-certification-mock-exams/oracle-certified-professional/ocp-java-21-exam-1z0-830). They are only $10 and you get 20 mock exams! Excellent practice after you study to get ready. The OCP forum at [CodeRanch](https://coderanch.com/f/24/java-programmer-OCPJP) is also a great place to ask questions as you prepare for your certification.

--- a/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
+++ b/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
@@ -40,7 +40,7 @@ There are currently a number of active Java certification exams.
 4. [1Z0-809: Java SE 8 Programmer II exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-809) - 68 questions, passing 65% - This is the second half of the Java 8 exam.
 5. [1Z0-811: Java Foundations exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-811) - 60 questions, passing 65% - The foundations exam was introduced for those in Oracle Academy. It is far less common than the other exams. It uses Java 8 as well.
 
-Most people start with one of the latest two (1ZO-831 for Java 25 or 1Z0-830 for Java 21). Some start with the 1Z)-811 if they want to start with an easy certification faster. It is very important to use study materials that match the exam you are studying for. For example, those who hold Java 21 materials target the 1Z0-830 exam.
+Most people start with one of the latest two (1Z0-831 for Java 25 or 1Z0-830 for Java 21). Some start with the 1Z0-811 if they want to start with an easy certification faster. It is very important to use study materials that match the exam you are studying for. For example, you should target the 1Z0-830 exam if you hold Java 21 materials.
 
 <a id="next-version">&nbsp;</a>
 ## Should I wait for the next version of the certification?

--- a/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
+++ b/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
@@ -32,8 +32,8 @@ Learning and jobs reasons tend to be the most common reasons to get a Java certi
 
 There are currently a number of active Java certification exams.
 
-1. [1Z0-831: Java SE 25 Developer Professional exam](https://education.oracle.com/java-se-25-developer-professional/pexam_1Z0-831) - 50 questions in 120 minutes, passing 68% - For Java 21; =the most recent certification exam available.
-1. [1Z0-830: Java SE 21 Developer Professional exam](https://mylearn.oracle.com/ou/exam/java-se-21-developer-professional-1z0-830/105037/139080/220555) - 50 questions in 120 minutes, passing 68% - For Java 21; =the most recent certification exam available.
+1. [1Z0-831: Java SE 25 Developer Professional exam](https://education.oracle.com/java-se-25-developer-professional/pexam_1Z0-831) - 50 questions in 120 minutes, passing 68% - For Java 21; the most recent certification exam available.
+1. [1Z0-830: Java SE 21 Developer Professional exam](https://education.oracle.com/java-se-21-developer-professional/pexam_1Z0-830) - 50 questions in 120 minutes, passing 68% - For Java 21; the most recent certification exam available.
 1. [1Z0-829: Java SE 17 Developer exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-829) - 50 questions, passing 68% - This Java 17 is the most recent certification exams available.
 2. [1Z0-819: Java SE 11 Developer exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-819) - 50 questions, passing 68% - For Java 11, the exam was launched in two parts like Java 8 (1Z0-815 and 1Z0-816). It was consolidated into a single exam, the 1Z0-819.  
 3. [1Z0-808: Java SE 8 Programmer I exam](https://education.oracle.com/java-ee-7-application-developer/pexam_1Z0-808) - 56 questions, passing 65% - For Java 8, the exam was split into two parts. You earn a certification for each one. . Taking this first half gives you a more basic certification while you work towards the 809.


### PR DESCRIPTION
Updated for Java 25. Note that this MR includes the relevant changes from https://github.com/java/devjava-content/pull/202 which was merged in on the public site but not this repo.

Also note that the Java 25 exam is *very* new so I will have another update when books are available. In fact, it is so new that it isn't even listed on https://www.oracle.com/education/certification/ yet!