### PR TITLE
Fix capitalization and punctuation inconsistencies on the Learn page

### DIFF
--- a/app/pages/learn/01_tutorial/01_your-first-java-app/02_building-with-intellij-idea.md
+++ b/app/pages/learn/01_tutorial/01_your-first-java-app/02_building-with-intellij-idea.md
@@ -1,6 +1,6 @@
 ---
 id: first_app.intellij-idea
-title: Building a Java application in IntelliJ IDEA
+title: Building a Java Application in IntelliJ IDEA
 slug: learn/intellij-idea
 type: tutorial
 category: start

--- a/app/pages/learn/01_tutorial/01_your-first-java-app/03_building-with-eclipse.md
+++ b/app/pages/learn/01_tutorial/01_your-first-java-app/03_building-with-eclipse.md
@@ -17,7 +17,7 @@ toc:
 - Generating Code {generating}
 - Refactoring {refactoring}
 - Summary {summary}
-description: "Installing and getting started with the Eclipse IDE for developing Java applications"
+description: "Installing and getting started with the Eclipse IDE for developing Java applications."
 last_update: 2024-04-15
 author: ["DanielSchmid"]
 ---

--- a/app/pages/learn/01_tutorial/03_getting-to-know-the-language/02_basics/00_language-basics.md
+++ b/app/pages/learn/01_tutorial/03_getting-to-know-the-language/02_basics/00_language-basics.md
@@ -14,4 +14,4 @@ main_css_id: learn
 description: "Getting to know the basics of the Java language."
 ---
 
-This part of the tutorial covers the basics of the language, including: variables, operators, expressions, statements, blocks and control flow statements.
+This part of the tutorial covers the basics of the language, including variables, operators, expressions, statements, blocks and control flow statements.

--- a/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/03_effects_gradients.md
+++ b/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/03_effects_gradients.md
@@ -15,7 +15,7 @@ toc:
 - Reflection {reflection}
 - Configuring Actions {config-actions}
 - Animation {animation}
-description: "Learn how to apply effects, gradients, animations to nodes in your scene graph. "
+description: "Learn how to apply effects, gradients, animations to nodes in your scene graph."
 last_update: 2023-09-12
 author: ["GailC.Anderson", "PaulAnderson"]
 byline: 'and is from <a href="https://link.springer.com/book/10.1007/978-1-4842-7268-8">The Definitive Guide to Modern Java Clients with JavaFX 17</a> graciously contributed by Apress.'

--- a/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/04_javafx_properties.md
+++ b/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/04_javafx_properties.md
@@ -16,7 +16,7 @@ toc:
 - Bidirectional Binding {unidir-binding}
 - Unidirectional Binding {bidir-binding}
 - Fluent API and Bindings API {fluent-api}
-description: "Control nodes by manipulating their properties. "
+description: "Control nodes by manipulating their properties."
 last_update: 2023-09-12
 author: ["GailC.Anderson", "PaulAnderson"]
 byline: 'and is from <a href="https://link.springer.com/book/10.1007/978-1-4842-7268-8">The Definitive Guide to Modern Java Clients with JavaFX 17</a> graciously contributed by Apress.'

--- a/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/05_fxml.md
+++ b/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/05_fxml.md
@@ -14,7 +14,7 @@ toc:
 - JavaFX Application Class {javafx-app-class}
 - Adding CSS {add-css}
 - Using Scene Builder {scene-builder}
-description: "Control nodes by manipulating their properties. "
+description: "Control nodes by manipulating their properties."
 last_update: 2023-09-12
 author: ["GailC.Anderson", "PaulAnderson"]
 byline: 'and is from <a href="https://link.springer.com/book/10.1007/978-1-4842-7268-8">The Definitive Guide to Modern Java Clients with JavaFX 17</a> graciously contributed by Apress.'

--- a/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/06_all_together.md
+++ b/app/pages/learn/01_tutorial/07_rich_client_apps/01_javafx/06_all_together.md
@@ -19,7 +19,7 @@ toc:
 - Person UI Application Actions {app-actions}
 - Person UI with Records {app-records}
 - Key Point Summary {summary}
-description: "Control nodes by manipulating their properties. "
+description: "Control nodes by manipulating their properties."
 last_update: 2023-09-12
 author: ["GailC.Anderson", "PaulAnderson"]
 byline: 'and is from <a href="https://link.springer.com/book/10.1007/978-1-4842-7268-8">The Definitive Guide to Modern Java Clients with JavaFX 17</a> graciously contributed by Apress.'

--- a/app/pages/learn/01_tutorial/07_rich_client_apps/02_introduction-javafx-animation.md
+++ b/app/pages/learn/01_tutorial/07_rich_client_apps/02_introduction-javafx-animation.md
@@ -1,6 +1,6 @@
 ---
 id: javafx.animation
-title: Introduction to JavaFX animations
+title: Introduction to JavaFX Animations
 slug: learn/javafx-animations
 type: tutorial
 group: rich-client-apps

--- a/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
+++ b/app/pages/learn/01_tutorial/08_more-resources/01_java-certification-overview.md
@@ -13,7 +13,7 @@ toc:
 - Should I wait for Java 21? {java-21}
 - What is covered {topics}
 - How to study {study}
-description: "Overview of the Java Certification and how to study"
+description: "Overview of the Java Certification and how to study."
 last_update: 2023-07-30
 author: ["JeanneBoyarsky"]
 ---

--- a/app/pages/learn/01_tutorial/08_more-resources/02_debugging.md
+++ b/app/pages/learn/01_tutorial/08_more-resources/02_debugging.md
@@ -16,7 +16,7 @@ toc:
 - Debugger basics {basic}
 - Advanced techniques {advanced}
 - Documentation {docs}
-description: "Learning how to use a debugger"
+description: "Learning how to use a debugger."
 last_update: 2023-11-05
 author: ["JeanneBoyarsky"]
 ---

--- a/app/pages/learn/index.md
+++ b/app/pages/learn/index.md
@@ -8,7 +8,7 @@ subheader_select: tutorials
 
 <div class="learn-group">
 
-## References for the latest release
+## References for the Latest Release
 
 - [Java Documentation](doc:java-documentation)
 - [Java API Docs](doc:java-api-docs)

--- a/docs/working-with-content.md
+++ b/docs/working-with-content.md
@@ -125,8 +125,8 @@ There are 7 entries on the tutorial welcome page:
 - Staying Aware of New Features
 - Getting to Know the Language
 - Mastering the API
-- Organizing your Application
-- Getting to know the JVM
+- Organizing Your Application
+- Getting to Know the JVM
 - References
 
 These 7 entries are hard-coded in the `template/pages/learn/index.html` page. A page is displayed under an entry on this page if it is a `tutorial` page that has the right `category` defined in its front matter.


### PR DESCRIPTION
The Learn index page mixes title case with sentence case, and some entry descriptions end with a period while others don't. This is a cosmetic consistency pass over the affected title: and description: frontmatter fields, no content, structure, or URL changes.
Changes

Heading and title capitalization

Several entries used sentence case where their siblings used title case. The most visible pair is on the Learn index itself, where two structurally parallel headings disagree:

Getting to Know the Language (title case)
Getting to know the JVM (sentence case)

Similar inconsistencies fixed:

Getting to know the JVM -> Getting to Know the JVM
Organizing your Application  -> Organizing Your Application
Building a Java application in IntelliJ IDEA -> Building a Java Application in IntelliJ IDEA
Introduction to JavaFX animations ->  Introduction to JavaFX Animations

Building a Java Application in the Eclipse IDE already used title case, so the three IDE entries now match. Introduction to JavaFX Animations now matches Introduction to Java Reflection and Introduction to Method Handles.

**Terminal punctuation in descriptions**

Most entry descriptions end with a period; these did not:

"Installing and getting started with the Eclipse IDE for developing Java applications"
"Learn to create advanced JavaFX animations"
"Overview of the Java Certification and how to study"
"Learning how to use a debugger"
